### PR TITLE
Travis and ScalaStyle integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ cache:
 
 script:
   # Your normal script
+  - sbt -J-XX:ReservedCodeCacheSize=256M scalastyle
   - sbt -J-XX:ReservedCodeCacheSize=256M test
 
   # Tricks to avoid unnecessary cache updates

--- a/backend/src/main/scala/org/denigma/drugage/AppMessages.scala
+++ b/backend/src/main/scala/org/denigma/drugage/AppMessages.scala
@@ -4,7 +4,7 @@ import com.typesafe.config.Config
 
 object AppMessages {
 
-  case class Start(config:Config)
+  case class Start(config: Config)
   case object Stop
 
 }

--- a/backend/src/main/scala/org/denigma/drugage/Auth.scala
+++ b/backend/src/main/scala/org/denigma/drugage/Auth.scala
@@ -15,4 +15,4 @@ trait Auth {
 
 }
 
-case class User(user:String,pass:String)
+case class User(user: String, pass: String)

--- a/backend/src/main/scala/org/denigma/drugage/Main.scala
+++ b/backend/src/main/scala/org/denigma/drugage/Main.scala
@@ -12,7 +12,7 @@ object Main extends App
   sys.addShutdownHook(system.shutdown())
 
   val config: Config = system.settings.config
-  var main:ActorRef = system.actorOf(Props[MainActor])
+  var main: ActorRef = system.actorOf(Props[MainActor])
   main ! AppMessages.Start(config)
 
 }

--- a/backend/src/main/scala/org/denigma/drugage/MainActor.scala
+++ b/backend/src/main/scala/org/denigma/drugage/MainActor.scala
@@ -16,27 +16,23 @@ class MainActor  extends Actor with ActorLogging // Routes
   implicit val materializer = ActorFlowMaterializer()
   implicit val executionContext = system.dispatcher
 
-
   val server: HttpExt = Http(context.system)
-  var serverSource: Source[IncomingConnection, Future[ServerBinding]] = null
+  var serverSource: Source[IncomingConnection, Future[ServerBinding]] = null  // scalastyle:ignore
   val router = new Router()
-
-
-
 
   override def receive: Receive = {
     case AppMessages.Start(config)=>
-      val (host,port) = (config.getString("app.host") , config.getInt("app.port"))
+      val (host, port) = (config.getString("app.host"), config.getInt("app.port"))
       server.bindAndHandle(router.routes, host, port)
 
     case AppMessages.Stop=> onStop()
   }
 
-  def onStop() = {
+  def onStop(): Unit = {
     log.info("Main actor has been stoped...")
   }
 
-  override def postStop() = {
+  override def postStop(): Unit = {
     onStop()
   }
 

--- a/backend/src/main/scala/org/denigma/drugage/routes/Head.scala
+++ b/backend/src/main/scala/org/denigma/drugage/routes/Head.scala
@@ -12,17 +12,16 @@ class Head extends Directives
   lazy val webjarsPrefix = "lib"
   lazy val resourcePrefix = "resources"
 
-  def mystyles =    path("styles" / "mystyles.css"){
+  def mystyles: Route = path("styles" / "mystyles.css"){
     complete  {
-      HttpResponse(  entity = HttpEntity(MediaTypes.`text/css`,  MyStyles.render   ))   }
+      HttpResponse(entity = HttpEntity(MediaTypes.`text/css`, MyStyles.render))}
   }
 
-  def loadResources = pathPrefix(resourcePrefix~Slash) {
+  def loadResources: Route = pathPrefix(resourcePrefix~Slash) {
     getFromResourceDirectory("")
   }
 
-
-  def webjars =pathPrefix(webjarsPrefix ~ Slash)  {  getFromResourceDirectory(webjarsPrefix)  }
+  def webjars: Route = pathPrefix(webjarsPrefix ~ Slash) {getFromResourceDirectory(webjarsPrefix)}
 
   def routes: Route = mystyles ~ webjars ~ loadResources
 }

--- a/backend/src/main/scala/org/denigma/drugage/routes/Pages.scala
+++ b/backend/src/main/scala/org/denigma/drugage/routes/Pages.scala
@@ -2,34 +2,30 @@ package org.denigma.drugage.routes
 
 import akka.http.extensions.pjax.PJax
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.server.Directives
+import akka.http.scaladsl.server.{Route, Directives}
 import play.twirl.api.Html
 
 import scalacss.Defaults._
 
-class Pages extends Directives with PJax{
+class Pages extends Directives with PJax {
 
-  def defaultPage:Option[Html] = None
+  def defaultPage: Option[Html] = None
 
-  def index =  pathSingleSlash{ctx=>
+  def index: Route = pathSingleSlash {ctx =>
     ctx.flowMaterializer.executionContext
     ctx.complete {
-      HttpResponse(  entity = HttpEntity(MediaTypes.`text/html`, html.index(defaultPage).body  ))
+      HttpResponse(entity = HttpEntity(MediaTypes.`text/html`, html.index(defaultPage).body))
     }
   }
 
-  val loadPage:Html=>Html = h=>html.index(Some(h))
+  val loadPage: Html=>Html = h => html.index(Some(h))
 
+  def test: Route = pathPrefix("test"~Slash) { ctx=>
+    pjax[Twirl](Html(s"<h1>${ctx.unmatchedPath}</h1>"), loadPage){h => c =>
+      val resp = HttpResponse(entity = HttpEntity(MediaTypes.`text/html`, h.body))
+      c.complete(resp)
+    }(ctx)
+  }
 
-  def test = pathPrefix("test"~Slash) { ctx=>
-      pjax[Twirl](Html(s"<h1>${ctx.unmatchedPath}</h1>"),loadPage){h=>c=>
-        val resp = HttpResponse(  entity = HttpEntity(MediaTypes.`text/html`, h.body  ))
-        c.complete(resp)
-      }(ctx)
-    }
-
-
-  def routes = index ~ test
-
-
+  def routes: Route = index ~ test
 }

--- a/backend/src/main/scala/org/denigma/drugage/routes/Router.scala
+++ b/backend/src/main/scala/org/denigma/drugage/routes/Router.scala
@@ -1,14 +1,14 @@
 package org.denigma.drugage.routes
 
 import akka.http.extensions.stubs._
-import akka.http.scaladsl.server.Directives
+import akka.http.scaladsl.server.{Route, Directives}
 
 
 class Router extends Directives {
-  val sessionController:SessionController = new InMemorySessionController
-  val loginController:FutureLoginController = new InMemoryLoginController
+  val sessionController: SessionController = new InMemorySessionController
+  val loginController: FutureLoginController = new InMemoryLoginController
 
-  def routes = new Head().routes ~
+  def routes: Route = new Head().routes ~
     new Registration(
       loginController.loginByName,
       loginController.loginByEmail,

--- a/backend/src/main/scala/org/denigma/drugage/routes/Twirl.scala
+++ b/backend/src/main/scala/org/denigma/drugage/routes/Twirl.scala
@@ -13,7 +13,7 @@ class Twirl extends TemplateEngine{
 import play.twirl.api.Html
 
 object Twirl{
-  implicit def apply(params:(Html,Html=>Html)):PJaxMagnet[Twirl] =
+  implicit def apply(params: (Html, Html => Html)): PJaxMagnet[Twirl] =
     PJaxMagnet[Twirl](
       Directive[Tuple1[Html]] { inner ⇒ ctx ⇒
         val (html, transform) = params
@@ -22,6 +22,4 @@ object Twirl{
         else
           inner(Tuple1(transform(html)))(ctx)
     })
-
-
 }

--- a/backend/src/main/scala/org/denigma/drugage/templates/Index.scala
+++ b/backend/src/main/scala/org/denigma/drugage/templates/Index.scala
@@ -7,22 +7,25 @@ import scalatags.Text.all._
 
 object Index {
 
-  lazy val items = for(e <- 0 until 5) yield a(`class` :="item",i(`class`:="lab icon"),s"Item #$e") //some test data
+  lazy val items = for {e <- 0 until 5} yield a(`class`:="item", i(`class`:="lab icon"), s"Item #$e") // some test data
 
-  lazy val HEAD =  head(
-    title := "Plasmids bank",
-    link(rel := "stylesheet", href := "styles/mystyles.css"), //my scalacss styles
-    script(`type` := "text/javascript", src := "lib/jquery/jquery.min.js"),
-    link(rel := "stylesheet", href := "lib/selectize.js/css/selectize.css"),
-    link(rel := "stylesheet", href := "lib/selectize.js/css/selectize.default.css"),
-    script(`type` := "text/javascript", src := "lib/selectize.js/js/standalone/selectize.js"), //for nice select boxes
-    link(rel := "stylesheet", href := "lib/Semantic-UI/semantic.css"),
-    script(`type` := "text/javascript", src := "lib/Semantic-UI/semantic.js") //http://semantic-ui.com/ is nice alternative to bootstrap
+  // scalastyle:off field.name
+  // scalastyle:off multiple.string.literals
+  lazy val HEAD = head(
+    title:="Plasmids bank",
+    link(rel:="stylesheet", href:="styles/mystyles.css"), // my scalacss styles
+    script(`type`:="text/javascript", src:="lib/jquery/jquery.min.js"),
+    link(rel:="stylesheet", href:="lib/selectize.js/css/selectize.css"),
+    link(rel:="stylesheet", href:="lib/selectize.js/css/selectize.default.css"),
+    script(`type`:="text/javascript", src:="lib/selectize.js/js/standalone/selectize.js"), // for nice select boxes
+    link(rel:="stylesheet", href:="lib/Semantic-UI/semantic.css"),
+    script(`type`:="text/javascript", src:="lib/Semantic-UI/semantic.js") // http://semantic-ui.com/ is nice alternative to bootstrap
     )
+  // scalastyle:on multiple.string.literals
 
-  lazy val MENU = div(`class` := "ui labeled green icon menu",items  )
-  lazy val MAIN = div(`class` := "ui green segment",h1("Hello World!"),
-    p(id:="hello",`class`:="desc","here will be hello world!")
+  lazy val MENU = div(`class`:="ui labeled green icon menu", items)
+  lazy val MAIN = div(`class`:="ui green segment", h1("Hello World!"),
+    p(id := "hello", `class`:="desc", "here will be hello world!")
   )
 
   lazy val scripts = Seq(
@@ -30,13 +33,9 @@ object Index {
     script(src:="resources/frontend-launcher.js")
   )
 
-  lazy val BODY = body( MENU, MAIN, div(scripts )
-  )
+  lazy val BODY = body(MENU, MAIN, div(scripts))
 
-  lazy val HTML = html(HEAD,BODY)
-
+  lazy val HTML = html(HEAD, BODY)
 
   lazy val template = HTML.render
-
-
 }

--- a/frontend/js/src/main/scala/org/denigma/drugage/FrontEnd.scala
+++ b/frontend/js/src/main/scala/org/denigma/drugage/FrontEnd.scala
@@ -20,7 +20,7 @@ import scala.util.Try
 object FrontEnd extends BindableView with scalajs.js.JSApp
 {
 
-  override def name = "main"
+  override def name: String = "main"
 
 
   val hello = Var("HELLO WORLD!")
@@ -39,21 +39,21 @@ object FrontEnd extends BindableView with scalajs.js.JSApp
    * Register views
    */
   ViewInjector
-    .register("menu", (el, params) =>Try(new MenuView(el,params)))
-    .register("sidebar", (el, params) =>Try(new SidebarView(el,params)))
-    .register("login", (el, params) =>Try(new LoginView(el,params)))
+    .register("menu", (el, params) => Try(new MenuView(el, params)))
+    .register("sidebar", (el, params) => Try(new SidebarView(el, params)))
+    .register("login", (el, params) => Try(new LoginView(el, params)))
 
   @JSExport
   def main(): Unit = {
     this.bindView(this.viewElement)
-    this.login("guest") //TODO: change it when session mechanism will work well
+    this.login("guest") // TODO: change it when session mechanism will work well
   }
 
   @JSExport
-  def login(username:String): Unit = Session.login(username)
+  def login(username: String): Unit = Session.login(username)
 
   @JSExport
-  def showLeftSidebar() = {
+  def showLeftSidebar(): Unit = {
     $(".left.sidebar").dyn.sidebar(sidebarParams).sidebar("show")
   }
 
@@ -77,7 +77,7 @@ object FrontEnd extends BindableView with scalajs.js.JSApp
     extractors.foreach(_.extractEverything(this))
   }
 
-  def attachBinders() = {
+  def attachBinders(): Unit = {
     this.binders = BindableView.defaultBinders(this)
   }
 }

--- a/frontend/js/src/main/scala/org/denigma/drugage/views/MenuView.scala
+++ b/frontend/js/src/main/scala/org/denigma/drugage/views/MenuView.scala
@@ -11,7 +11,7 @@ import scala.collection.immutable.Map
 
 object TestData{
 
-  val menuItems = List("Find Plasmids","Deposit Plasmids","How to Order","Plasmid Reference")
+  val menuItems = List("Find Plasmids", "Deposit Plasmids", "How to Order", "Plasmid Reference")
 
   val prefix = "test/"
 }
@@ -21,17 +21,17 @@ object TestData{
  * @param elem html element
  * @param params view params (if any)
  */
-class MenuView(val elem:HTMLElement, val params:Map[String,Any] = Map.empty) extends CollectionView
+class MenuView(val elem: HTMLElement, val params: Map[String, Any] = Map.empty) extends CollectionView
 {
 
   override def activateMacro(): Unit = { extractors.foreach(_.extractEverything(this))}
 
-  override protected def attachBinders(): Unit =withBinders(BindableView.defaultBinders(this))
+  override protected def attachBinders(): Unit = withBinders(BindableView.defaultBinders(this))
 
   override type Item = String
 
-  override def newItem(item: Item) = this.constructItem(item){ case (el,mp)=> //TODO: rename constructItem to smt like ConstructItemView
-    new MenuItem(el,item,mp)
+  override def newItem(item: Item): ItemView = this.constructItem(item){ case (el, mp)=> // TODO: rename constructItem to smt like ConstructItemView
+    new MenuItem(el, item, mp)
   }
 
   override type ItemView = MenuItem
@@ -43,10 +43,10 @@ class MenuView(val elem:HTMLElement, val params:Map[String,Any] = Map.empty) ext
 
 }
 
-class MenuItem(val elem:HTMLElement,value:String, val params:Map[String,Any] = Map.empty) extends BindableView{
+class MenuItem(val elem: HTMLElement, value: String, val params: Map[String, Any] = Map.empty) extends BindableView{
 
   val label: Var[String] = Var(value)
-  val uri: Rx[String] = label.map(l=>TestData.prefix+l.replace(" ","_"))
+  val uri: Rx[String] = label.map(l => TestData.prefix + l.replace(" ", "_"))
 
 
   override def activateMacro(): Unit = { extractors.foreach(_.extractEverything(this))}

--- a/frontend/js/src/main/scala/org/denigma/drugage/views/SidebarView.scala
+++ b/frontend/js/src/main/scala/org/denigma/drugage/views/SidebarView.scala
@@ -7,18 +7,18 @@ import org.querki.jquery._
 import org.scalajs.dom.raw.HTMLElement
 import rx._
 /**
- * View for the sitebar
+ * View for the sidebar
  */
-class SidebarView (val elem:HTMLElement,val params:Map[String,Any] = Map.empty[String,Any]) extends BindableView with WithDomain{
+class SidebarView (val elem: HTMLElement, val params: Map[String, Any] = Map.empty[String, Any]) extends BindableView with WithDomain{
 
   override def activateMacro(): Unit = { extractors.foreach(_.extractEverything(this))}
 
   val logo = Var("/resources/drugs_lifespan.gif")
 
-  override def bindElement(el:HTMLElement) = {
+  override def bindElement(el: HTMLElement): Unit = {
     super.bindElement(el)
     $(".ui.accordion").dyn.accordion()
   }
 
-  override protected def attachBinders(): Unit =  binders =  BindableView.defaultBinders(this)
+  override protected def attachBinders(): Unit =  binders = BindableView.defaultBinders(this)
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -12,22 +12,22 @@ import com.typesafe.sbt.web.SbtWeb.autoImport._
 
 object Build extends sbt.Build {
   
-	//settings for all the projects
+	// settings for all the projects
 	lazy val commonSettings = Seq(
     scalaVersion := Versions.scala,
 	  organization := "org.denigma",
-		resolvers += sbt.Resolver.bintrayRepo("denigma", "denigma-releases"), //for scala-js-binding
+		resolvers += sbt.Resolver.bintrayRepo("denigma", "denigma-releases"), // for scala-js-binding
     libraryDependencies ++= Dependencies.commonShared.value++Dependencies.testing.value,
-		updateOptions := updateOptions.value.withCachedResolution(true), //to speed up dependency resolution
-		scalacOptions in ThisBuild ++= Seq("-unchecked", "-deprecation", "-feature")
+		updateOptions := updateOptions.value.withCachedResolution(true), // to speed up dependency resolution
+		scalacOptions in ThisBuild ++= Seq("-unchecked", "-deprecation", "-feature", "-language:implicitConversions")
   )
 
-	//sbt-native-packager settings to run it as daemon
+	// sbt-native-packager settings to run it as daemon
 	lazy val packageSettings = Seq(
 		maintainer := "Anton Kulaga <antonkulaga@gmail.com>",
 		packageSummary:= "DrugAge database prototype",
 		packageDescription := "DrugAge database prototype"
-		//serverLoading in Debian := Upstart
+		// serverLoading in Debian := Upstart
 	)
 
 	lazy val frontend = crossProject
@@ -42,11 +42,11 @@ object Build extends sbt.Build {
 		libraryDependencies ++= Dependencies.sjsLibs.value++Dependencies.templates.value
 )
 
-	lazy val frontendJVM = frontend.jvm //what frontend requires from the backend
-	lazy val frontendJS = frontend.js //all scalajs code is here
+	lazy val frontendJVM = frontend.jvm // what frontend requires from the backend
+	lazy val frontendJS = frontend.js // all scalajs code is here
 
 
-	//backend project
+	// backend project
 	lazy val backend = Project("backend", file("backend"),settings = commonSettings++Revolver.settings)
 		.settings(packageSettings:_*)
 		.settings(
@@ -63,6 +63,6 @@ object Build extends sbt.Build {
 		.settings(
 			mainClass in Compile := (mainClass in backend in Compile).value,
 			libraryDependencies += "com.lihaoyi" % "ammonite-repl" % Versions.ammonite cross CrossVersion.full,
-			initialCommands in console := """ammonite.repl.Repl.run("")""" //better console
+			initialCommands in console := """ammonite.repl.Repl.run("")""" // better console
     ) dependsOn backend aggregate(backend,frontendJS)
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,7 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.3") //ScalaJS
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.1.1") //templates
 
 addSbtPlugin("com.gilt" % "sbt-dependency-graph-sugar" % "0.7.5") //visual dependency management
+
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.7.0")
+
+resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -1,0 +1,137 @@
+<scalastyle>
+ <name>Scalastyle standard configuration</name>
+ <check level="error" class="org.scalastyle.file.FileTabChecker" enabled="true"/>
+ <check level="error" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxFileLength"><![CDATA[800]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"/>
+ <check level="error" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"/>
+ <check level="error" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"/>
+ <check level="error" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxLineLength"><![CDATA[160]]></parameter>
+   <parameter name="tabSize"><![CDATA[4]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
+     <parameters>
+   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"/>
+ <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+  <parameters>
+   <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
+  <parameters>
+   <parameter name="maxParameters"><![CDATA[8]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
+  <parameters>
+   <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"/>
+ <check level="error" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"/>
+ <check level="error" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"/>
+ <check level="error" class="org.scalastyle.scalariform.NullChecker" enabled="true"/>
+ <check level="error" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"/>
+ <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"/>
+ <check level="error" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"/>
+ <check level="error" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"/>
+ <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[println]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
+  <parameters>
+   <parameter name="maxTypes"><![CDATA[30]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
+  <parameters>
+   <parameter name="maximum"><![CDATA[10]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"/>
+ <check level="error" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"/>
+ <check level="error" class="org.scalastyle.scalariform.IfBraceChecker" enabled="false">
+  <parameters>
+   <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
+   <parameter name="doubleLineAllowed"><![CDATA[false]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxLength"><![CDATA[50]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
+  <parameters>
+   <parameter name="maxMethods"><![CDATA[30]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"/>
+ <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"/>
+ <check level="error" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"/>
+ <check enabled="true" class="org.scalastyle.file.IndentationChecker" level="error">
+  <parameters>
+   <parameter name="tabSize">2</parameter>
+  </parameters>
+ </check>
+ <check enabled="false" class="org.scalastyle.scalariform.BlockImportChecker" level="error"/>
+ <check enabled="true" class="org.scalastyle.scalariform.DeprecatedJavaChecker" level="error"/>
+    <check enabled="true" class="org.scalastyle.scalariform.DisallowSpaceAfterTokenChecker" level="error">
+     <parameters>
+      <parameter name="tokens">LPAREN</parameter>
+     </parameters>
+    </check>
+    <check enabled="true" class="org.scalastyle.scalariform.DisallowSpaceBeforeTokenChecker" level="error">
+     <parameters>
+      <parameter name="tokens">COLON, COMMA, RPAREN</parameter>
+     </parameters>
+    </check>
+    <check enabled="true" class="org.scalastyle.scalariform.EmptyClassChecker" level="error"/>
+    <check enabled="true" class="org.scalastyle.scalariform.EnsureSingleSpaceAfterTokenChecker" level="error">
+     <parameters>
+      <parameter name="tokens">COLON, IF, COMMA</parameter>
+     </parameters>
+    </check>
+    <check enabled="true" class="org.scalastyle.scalariform.FieldNamesChecker" level="error">
+     <parameters>
+      <parameter name="regex">^[(a-z][A-Za-z0-9),]*$</parameter>
+     </parameters>
+    </check>
+    <check enabled="true" class="org.scalastyle.scalariform.ForBraceChecker" level="error"/>
+    <check enabled="true" class="org.scalastyle.scalariform.LowercasePatternMatchChecker" level="error"/>
+    <check enabled="true" class="org.scalastyle.scalariform.MultipleStringLiteralsChecker" level="error">
+     <parameters>
+      <parameter name="allowed">1</parameter>
+      <parameter name="ignoreRegex">^\&quot;\&quot;$</parameter>
+     </parameters>
+    </check>
+    <check enabled="true" class="org.scalastyle.scalariform.ProcedureDeclarationChecker" level="error"/>
+    <check enabled="true" class="org.scalastyle.scalariform.RedundantIfChecker" level="error"/>
+    <check enabled="true" class="org.scalastyle.scalariform.SpaceAfterCommentStartChecker" level="error"/>
+</scalastyle>


### PR DESCRIPTION
@antonkulaga, Я решил немного потрафить своему "OCD" и добавил в проект проверки на ScalaStyle. Меня жутко напрягает, когда стиль исходного кода плавает от файла к файлу. Очень мешает при быстром чтении кода.
Проверка запускается через sbt scalastyle, любой ворнинг интерпретируется как ошибка. Правила там очень простые, совпадают с хотелками Одерски в его курсе. Если что-то будет мешать -- уберём. В отдельных случаях проверки можно отключать: http://www.scalastyle.org/configuration.html

Естественно добавил интеграцию с Тревисом и ScalaStyle там прогоняется. Сейчас привёл всю имеющуюся кодобазу в вылизанное в соответствии с требованиями стиля состояние.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/denigma/drugage/1)

<!-- Reviewable:end -->
